### PR TITLE
Remove redundant type field from node info panel

### DIFF
--- a/frontend/src/pages/GraphPage.jsx
+++ b/frontend/src/pages/GraphPage.jsx
@@ -538,10 +538,12 @@ export default function GraphPage() {
   }, [])
 
   const sticky = stickyNode ? {
-    rows: Object.entries(stickyNode.details).map(([label, value]) => ({
-      label,
-      value,
-    })),
+    rows: Object.entries(stickyNode.details)
+      .filter(([label]) => label !== 'type')
+      .map(([label, value]) => ({
+        label,
+        value,
+      })),
   } : null
 
   return (


### PR DESCRIPTION
## What

Removes the `type` field from the node detail rows in the graph side panel.

## Why

The panel header already displays the node type via `fileTypeLabel()` — showing it again as a row is redundant. Fixes #57.

## Change

In `GraphPage.jsx`, added a `.filter(([label]) => label !== 'type')` before mapping `stickyNode.details` entries to rows.