### PR TITLE
fix: remove redundant type field from node info panel

### DIFF
--- a/frontend/src/pages/GraphPage.jsx
+++ b/frontend/src/pages/GraphPage.jsx
@@ -538,10 +538,12 @@ export default function GraphPage() {
   }, [])
 
   const sticky = stickyNode ? {
-    rows: Object.entries(stickyNode.details).map(([label, value]) => ({
-      label,
-      value,
-    })),
+    rows: Object.entries(stickyNode.details)
+      .filter(([label]) => label !== 'type')
+      .map(([label, value]) => ({
+        label,
+        value,
+      })),
   } : null
 
   return (


### PR DESCRIPTION
The `type` field shown in the node info panel is already conveyed by the node's visual representation (color/shape). Removing it reduces clutter in the panel without losing information.